### PR TITLE
Remove "parser" override (Fixes #3)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
             prettierOptions.tabWidth = indentation;
         }
     }
-    prettierOptions.parser = 'postcss';
+
     debug('prettier %O', prettierOptions);
     debug('linter %O', stylelintConfig);
 


### PR DESCRIPTION
Prettier can determine the parser perfectly fine, and it can also be defined in the prettier config file.